### PR TITLE
Add tiktoken to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ langchain
 openai
 python-dotenv
 deeplake
+tiktoken


### PR DESCRIPTION
`github.py` failed with error:

```
  File "/home/conrad/src/ai/Chat-with-Github-Repo/CwGH/lib/python3.10/site-packages/langchain/embeddings/openai.py", line 201, in _get_len_safe_embeddings
    raise ValueError(
ValueError: Could not import tiktoken python package. This is needed in order to for OpenAIEmbeddings. Please install it with `pip install tiktoken`.
```